### PR TITLE
change idx within a group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flatlist-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2099,7 +2099,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
       "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -2225,7 +2224,6 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ interface Props {
     groupSeparator?: null | any;
     dontSortOnGroup?: boolean;
     ignoreCaseOnWhenSorting?: boolean;
-    renderItem: (item: any, idx: number) => any;
+    renderItem: (item: any, idx: number | string) => any;
     renderWhenEmpty?: null | (() => any);
     filterBy?: string | ((item: any, idx: number) => boolean);
     groupBy?: string | ((item: any, idx: number) => boolean);
@@ -147,7 +147,7 @@ class FlatList extends Component<Props, {}> {
                 by: isString(groupBy) ? groupBy as string : '',
                 every: groupOf || 0,
                 on: isFunction(groupBy) ? groupBy as any : null
-            }).reduce(((groupedList, group, idx) => {
+            }).reduce(((groupedList, group, idx: number) => {
                 const separatorKey = `${idx}-${group.length}`;
                 let separator = (<hr key={separatorKey} className='___list-separator'/>);
 
@@ -172,11 +172,13 @@ class FlatList extends Component<Props, {}> {
                     });
                 }
 
+                const groupedItems = group.map((item: any, i: number) => renderItem(item, `${idx}-${i}`));
+
                 if (showGroupSeparatorAtTheBottom) {
-                    return groupedList.concat(...group.map(renderItem), separator);
+                    return groupedList.concat(...groupedItems, separator);
                 }
 
-                return groupedList.concat(separator, ...group.map(renderItem));
+                return groupedList.concat(separator, ...groupedItems);
             }), [])
         );
     }


### PR DESCRIPTION
this PR allows for when you are grouping items the index do not repeat in between groups. For example, if you have 2 groups with each 2 items the index for these items would be:

[0, 1], [0, 1]

and with this change the index will be:

[0-0, 0-1], [1-0, 1-1]

where the first part is the index of the group and the other is the index of the item.