### PR TITLE
Remove limit group prop and use group of instead

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -246,7 +246,7 @@ export default class FlatList extends PureComponent<Props, {}> {
             limit: groupOf
         };
 
-        const {list: groupLists, groupLabels} = groupList(renderList, groupingOptions);
+        const {groupLists, groupLabels} = groupList(renderList, groupingOptions);
 
         return (groupLists
                 .reduce(((groupedList, group, idx: number) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,9 +2,9 @@ import React, {Fragment, PureComponent, createRef} from 'react';
 import {array, func, oneOfType, string, bool, node, element, number} from 'prop-types';
 import filterList from './utils/filterList';
 import sortList from './utils/sortList';
-import groupList from './utils/groupList';
+import groupList, {GroupOptionsInterface} from './utils/groupList';
 import limitList from './utils/limitList';
-import {isString, isFunction} from './utils/isType';
+import {isFunction} from './utils/isType';
 
 declare global {
     namespace JSX {
@@ -22,7 +22,6 @@ interface Props {
     sortGroupDesc?: boolean;
     showGroupSeparatorAtTheBottom?: boolean;
     limit?: number;
-    limitGroup?: number;
     sort?: boolean;
     displayRow?: boolean;
     rowGap?: string;
@@ -35,8 +34,8 @@ interface Props {
     renderItem: (item: any, idx: number | string) => any;
     renderWhenEmpty?: null | (() => any);
     filterBy?: string | ((item: any, idx: number) => boolean);
-    groupBy?: string | ((item: any, idx: number) => boolean);
-    groupOf?: number;
+    groupBy?: GroupOptionsInterface['by'];
+    groupOf?: GroupOptionsInterface['limit'];
 }
 
 export default class FlatList extends PureComponent<Props, {}> {
@@ -75,10 +74,6 @@ export default class FlatList extends PureComponent<Props, {}> {
          * the number representing the max number of items to display
          */
         limit: number,
-        /**
-         * the number representing the max number of items to display inside a group
-         */
-        limitGroup: number,
         /**
          * a list of anything to be displayed
          */
@@ -243,15 +238,15 @@ export default class FlatList extends PureComponent<Props, {}> {
     public renderGroupedList = (renderList: any[]) => {
         const {
             renderItem, groupBy, sort, sortGroupBy, sortGroupDesc,
-            ignoreCaseOnWhenSorting, groupSeparator, groupOf, showGroupSeparatorAtTheBottom, limitGroup
+            ignoreCaseOnWhenSorting, groupSeparator, groupOf, showGroupSeparatorAtTheBottom
         } = this.props;
 
-        const {list: groupLists, groupLabels} = groupList(renderList, {
-            by: isString(groupBy) ? groupBy as string : '',
-            every: groupOf || 0,
-            max: limitGroup,
-            on: isFunction(groupBy) ? groupBy as any : null
-        });
+        const groupingOptions: GroupOptionsInterface = {
+            by: groupBy,
+            limit: groupOf
+        };
+
+        const {list: groupLists, groupLabels} = groupList(renderList, groupingOptions);
 
         return (groupLists
                 .reduce(((groupedList, group, idx: number) => {

--- a/src/utils/groupList.ts
+++ b/src/utils/groupList.ts
@@ -25,6 +25,7 @@ const groupList = <T>(list: T[], options: GroupOptionsInterface = defaultGroupOp
     const {by: groupBy, limit} = options;
 
     if (groupBy && (isFunction(groupBy) || isString(groupBy))) {
+
         const groupedList: GroupedItemsObjectInterface<T> = list
             .reduce((prevList: GroupedItemsObjectInterface<T>, item: T, idx: number) => {
                 const groupLabel = isFunction(groupBy) ?
@@ -46,7 +47,9 @@ const groupList = <T>(list: T[], options: GroupOptionsInterface = defaultGroupOp
         groupLabels = Array.from(new Set(Object.keys(groupedList)));
 
         return {groupLabels, groupLists: Object.values(groupedList)};
+
     } else if (limit && isNumber(limit) && (limit > 0)) {
+
         const groupLists = list.reduce((groupedList: any[], item: T, idx: number) => {
             groupedList[groupedList.length - 1].push(item);
 

--- a/src/utils/groupList.ts
+++ b/src/utils/groupList.ts
@@ -45,12 +45,9 @@ const groupList = <T>(list: T[], options: GroupOptionsInterface = defaultGroupOp
         // using Set here so the order is preserved and prevent duplicates
         groupLabels = Array.from(new Set(Object.keys(groupedList)));
 
-        return {
-            groupLabels,
-            list: Object.values(groupedList)
-        };
+        return {groupLabels, groupLists: Object.values(groupedList)};
     } else if (limit && isNumber(limit) && (limit > 0)) {
-        const groupOfList = list.reduce((groupedList: any[], item: T, idx: number) => {
+        const groupLists = list.reduce((groupedList: any[], item: T, idx: number) => {
             groupedList[groupedList.length - 1].push(item);
 
             const itemNumber: number = idx + 1;
@@ -65,13 +62,10 @@ const groupList = <T>(list: T[], options: GroupOptionsInterface = defaultGroupOp
             return groupedList;
         }, [[]]);
 
-        return {groupLabels, list: groupOfList};
+        return {groupLabels, groupLists};
     }
 
-    return {
-        groupLabels,
-        list: [list]
-    };
+    return {groupLabels, groupLists: [list]};
 };
 
 export default groupList;


### PR DESCRIPTION
this
-- removes limitGroup prop
-- refactor groupList util to combine groupBy and groupOf
-- fixes groupList bug where if no groupBy of groupOf it was returning a full list instead of a group of the whole list