### PR TITLE
Release 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 lib
 .npmignore
 tools
+coverage

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ grouping, searching, styling and more.
         * [renderWhenEmpty prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#renderwhenempty-prop)
         * [limit prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#limit-prop)
         * [reversed prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#reversed-prop)
+    * [Paginating list (Infinite Loader)](https://github.com/ECorreia45/flatlist-react/tree/documentation#paginating-list)
+        * [hasMoreItems prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#hasmoreitems-prop)
+        * [loadMoreItems prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#loadmoreitems-prop)
+        * [paginationLoadingIndicator prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#paginationloadingindicator-prop)
+        * [paginationLoadingIndicatorPosition prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#paginationloadingindicatorposition-prop)
+        * [paginate prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#paginate-prop)
     * [Dot Notation for string](https://github.com/ECorreia45/flatlist-react/tree/documentation#dot-notation-for-string)
     * [Filtering Items](https://github.com/ECorreia45/flatlist-react/tree/documentation#filteringsearching-items)
         * [filterBy prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#filterby-prop)
@@ -210,6 +216,132 @@ if you want to limit the size of the groups.
 This simply reverse the provided list. Instead of reading the list from first to last item it will do the reverse. There is also 
 [groupReversed](https://github.com/ECorreia45/flatlist-react/tree/documentation#groupreversed-prop) 
 if you want the same effect on the individual groups.
+
+#### Paginate list
+You don't have to start with a full list from the beginning. Flatlist allows you to specify that the list you gave
+is not complete and a handler to call when user scrolled to the end of the list. You can specify a loading indicator
+component to show while you are fetching the next page of the list. This feature works really well with api. Let's take
+the following situation:
+
+```jsx
+
+state={
+    hasMorePeople: false,
+    nextOffset: 0
+}
+
+componentDidMount() {
+    this.fetchPeople();
+}
+
+fetchPeople() {
+    this.api.getPeople({perPage: 10, offset: this.state.nextOffset})
+        .then(res => {
+            this.setState(prevState => ({
+                            people: [...prevState.people, ...res.data], 
+                            nextOffset: res.data.pagination.nextOffset,
+                            hasMorePeople: res.data.pagination.max > prevState.people.length
+                        }));
+        });
+}
+
+render() {
+    const {people} = this.state;
+    return (
+        <ul>
+            <FlatList 
+                list={people} 
+                renderItem={this.renderPerson}
+                />
+        </ul>
+    );
+}
+
+```
+
+##### hasMoreItems prop
+`hasMoreItems` is the prop to communicate with FlatList that the `list` you provided is not complete. This prop by itself
+will not do anything until you provide `loadMoreItems` prop. This is a boolean representing whether you are done paginating
+or not.
+
+##### loadMoreItems prop
+`loadMoreItems` is the function to call when user has scrolled to the end of the list. FlatList will wait till the user
+reached the bottom to call this handler as long as `hasMoreItems` is true. Otherwise it will remove the loader all
+together. This function does not need to return anything. In our example above, we would do as so:
+
+```jsx
+...
+render() {
+    const {people, hasMorePeople} = this.state;
+    return (
+        <ul>
+            <FlatList 
+                list={people} 
+                renderItem={this.renderPerson}
+                hasMoreItems={hasMorePeople}
+                loadMoreItems={this.fetchPeople}
+                />
+        </ul>
+    );
+}
+```
+
+##### paginationLoadingIndicator prop
+The default `paginationLoadingIndicator` is pretty basic(for now) and you might feel the need to change it to your
+liking and this is the prop to use. This prop can be a component/element or a function that return a component/element.
+
+##### paginationLoadingIndicatorPosition prop
+By default, the loading indicator will be positioned on the left. You can use `paginationLoadingIndicatorPosition` to
+position the loading indicator whether or the `center`, `right` or `left`(default).
+
+```jsx
+...
+render() {
+    const {people, hasMorePeople} = this.state;
+    return (
+        <ul>
+            <FlatList 
+                list={people} 
+                renderItem={this.renderPerson}
+                hasMoreItems={hasMorePeople}
+                loadMoreItems={this.fetchPeople}
+                paginationLoadingIndicator={<Loader/>}
+                paginationLoadingIndicatorPosition="center"
+                />
+        </ul>
+    );
+}
+```
+##### pagination prop
+The `pagination` prop is the pagination shorthand. It does everything specified above but it is a object configuration
+with the following format
+* `hasMore` (same as [hasMoreItems prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#hasmoreitems-prop))
+* `loadMore` (same as [loadMoreItems prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#loadmoreitems-prop))
+* `loadingIndicator` (same as [paginationLoadingIndicator prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#paginationloadingindicator-prop))
+* `loadingIndicatorPosition` (same as [paginationLoadingIndicatorPosition prop](https://github.com/ECorreia45/flatlist-react/tree/documentation#paginationloadingindicatorposition-prop))
+
+So we could write the above example as:
+
+```jsx
+...
+render() {
+    const {people, hasMorePeople} = this.state;
+    return (
+        <ul>
+            <FlatList 
+                list={people} 
+                renderItem={this.renderPerson}
+                pagination={{
+                    hasMore={hasMorePeople}
+                    loadMore={this.fetchPeople}
+                    loadingIndicator={<Loader/>}
+                    loadingIndicatorPosition="center"
+                }}
+                />
+        </ul>
+    );
+}
+```
 
 ### Note
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatlist-react",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A helpful utility component to handle lists in react like a champ",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/flatlist-react.tsx
+++ b/src/flatlist-react.tsx
@@ -1,5 +1,5 @@
 import React, {Fragment, memo, forwardRef, Ref, ForwardRefExoticComponent} from 'react';
-import {array, func, oneOfType, string, bool, node, element, number, shape, object} from 'prop-types';
+import {array, func, oneOfType, string, bool, node, element, number, shape, object, oneOf} from 'prop-types';
 import filterList from './utils/filterList';
 import sortList from './utils/sortList';
 import searchList, {SearchOptionsInterface} from './utils/searchList';
@@ -9,6 +9,7 @@ import convertListToArray from './utils/convertListToArray';
 import limitList from './utils/limitList';
 import DefaultBlank from './subComponents/DefaultBlank';
 import DisplayHandler, {DisplayHandlerProps, DisplayInterface} from './subComponents/DisplayHandler';
+import InfiniteLoader, {InfiniteLoaderInterface} from './subComponents/InfiniteLoader';
 
 interface GroupInterface extends GroupOptionsInterface {
     separator: JSX.Element | ((g: any, idx: number, label: string) => JSX.Element | null) | null;
@@ -39,12 +40,13 @@ interface Props {
     search: SearchOptionsInterface;
     display: DisplayInterface;
     sort: boolean | SortInterface;
+    pagination: InfiniteLoaderInterface;
     // sorting
     sortBy: SortInterface['by'];
     sortCaseInsensitive: SortInterface['caseInsensitive'];
     sortDesc: SortInterface['descending'];
-    sortGroupBy: string;
-    sortGroupDesc: boolean;
+    sortGroupBy: GroupInterface['sortBy'];
+    sortGroupDesc: GroupInterface['sortDescending'];
     // grouping
     showGroupSeparatorAtTheBottom: GroupInterface['separatorAtTheBottom'];
     groupReversed: GroupInterface['reversed'];
@@ -64,6 +66,11 @@ interface Props {
     searchBy: SearchOptionsInterface['by'];
     searchOnEveryWord: SearchOptionsInterface['everyWord'];
     searchCaseInsensitive: SearchOptionsInterface['caseInsensitive'];
+    // pagination
+    hasMoreItems: InfiniteLoaderInterface['hasMore'];
+    loadMoreItems: null | InfiniteLoaderInterface['loadMore'];
+    paginationLoadingIndicator: InfiniteLoaderInterface['loadingIndicator'];
+    paginationLoadingIndicatorPosition: InfiniteLoaderInterface['loadingIndicatorPosition'];
 }
 
 // this interface is to deal with the fact that ForwardRefExoticComponent does not have the propTypes
@@ -79,6 +86,8 @@ const FlatList = forwardRef((props: Props, ref: Ref<HTMLElement>) => {
         sortBy, sortDesc, sort, sortCaseInsensitive, sortGroupBy, sortGroupDesc, // sort props
         searchBy, searchOnEveryWord, searchTerm, searchCaseInsensitive, // search props
         display, displayRow, rowGap, displayGrid, gridGap, minColumnWidth, // display props,
+        hasMoreItems, loadMoreItems, paginationLoadingIndicator, paginationLoadingIndicatorPosition,
+        pagination, // pagination props
         ...otherProps // props to be added to the wrapper container if wrapperHtmlTag is specified
     } = props;
     let {list, group, search} = props;
@@ -212,6 +221,13 @@ const FlatList = forwardRef((props: Props, ref: Ref<HTMLElement>) => {
                 {...{display, displayRow, rowGap, displayGrid, gridGap, minColumnWidth}}
                 showGroupSeparatorAtTheBottom={group.separatorAtTheBottom || showGroupSeparatorAtTheBottom}
             />
+            {(loadMoreItems || pagination.loadMore) &&
+                <InfiniteLoader
+                  hasMore={hasMoreItems || pagination.hasMore}
+                  loadMore={loadMoreItems || pagination.loadMore}
+                  loadingIndicator={paginationLoadingIndicator || pagination.loadingIndicator}
+                  loadingIndicatorPosition={paginationLoadingIndicatorPosition || pagination.loadingIndicatorPosition}
+                />}
         </Fragment>
     );
 
@@ -288,6 +304,10 @@ FlatList.propTypes = {
      */
     groupSeparator: oneOfType([node, func, element]),
     /**
+     * a flag to indicate whether there are more items to the list that can be loaded
+     */
+    hasMoreItems: bool,
+    /**
      * the number representing the max number of items to display
      */
     limit: number,
@@ -296,9 +316,21 @@ FlatList.propTypes = {
      */
     list: oneOfType([array, object]).isRequired,
     /**
+     * a function to be called when list has been scrolled to the end
+     */
+    loadMoreItems: func,
+    /**
      * the minimum column width when display grid is activated
      */
     minColumnWidth: string,
+    /**
+     * a custom element to be used instead of the default loading indicator for pagination
+     */
+    paginationLoadingIndicator: oneOfType([node, func, element]),
+    /**
+     * the position of the custom loader indicator
+     */
+    paginationLoadingIndicatorPosition: oneOf(['left', 'center', 'right', '']),
     /**
      * a jsx element or a function that it is called for every item on the list and returns a jsx element
      */
@@ -404,8 +436,12 @@ FlatList.defaultProps = {
     groupOf: 0,
     groupReversed: false,
     groupSeparator: null,
+    hasMoreItems: false,
     limit: 0,
+    loadMoreItems: null,
     minColumnWidth: '',
+    paginationLoadingIndicator: undefined,
+    paginationLoadingIndicatorPosition: '',
     renderWhenEmpty: null,
     reversed: false,
     rowGap: '',

--- a/src/flatlist-react.tsx
+++ b/src/flatlist-react.tsx
@@ -90,7 +90,8 @@ const FlatList = forwardRef((props: Props, ref: Ref<HTMLElement>) => {
         pagination, // pagination props
         ...otherProps // props to be added to the wrapper container if wrapperHtmlTag is specified
     } = props;
-    let {list, group, search} = props;
+    // tslint:disable-next-line:prefer-const
+    let {list, group, search, ...tagProps} = otherProps;
 
     list = convertListToArray(list);
 
@@ -154,7 +155,7 @@ const FlatList = forwardRef((props: Props, ref: Ref<HTMLElement>) => {
                             <separator.type
                                 {...separator.props}
                                 key={separatorKey}
-                                className={`${separator.props.className} ___list-separator`}
+                                className={`${separator.props.className || ''} ___list-separator`.trim()}
                             />
                         );
                     }
@@ -238,7 +239,7 @@ const FlatList = forwardRef((props: Props, ref: Ref<HTMLElement>) => {
             {
                 WrapperElement ?
                     // @ts-ignore
-                    <WrapperElement ref={ref}{...otherProps}>{content}</WrapperElement> :
+                    <WrapperElement ref={ref}{...tagProps}>{content}</WrapperElement> :
                     content
             }
         </Fragment>

--- a/src/subComponents/DefaultLoadIndicator.tsx
+++ b/src/subComponents/DefaultLoadIndicator.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const DefaultBlank = (
+    <div className='loading-indicator'>
+        loading...
+    </div>
+);
+
+export default DefaultBlank;

--- a/src/subComponents/DisplayHandler.tsx
+++ b/src/subComponents/DisplayHandler.tsx
@@ -86,6 +86,8 @@ class DisplayHandler extends Component<DisplayHandlerProps, State> {
   styleParentGrid(parentComponent: HTMLElement) {
     const {display, displayGrid} = this.props;
 
+    const infiniteLoader = parentComponent.querySelector<HTMLElement>('.__infinite-loader');
+
     if (displayGrid || display.grid) {
       let {gridGap, minColumnWidth} = this.props;
       const {defaultProps} = DisplayHandler;
@@ -102,6 +104,10 @@ class DisplayHandler extends Component<DisplayHandlerProps, State> {
           .forEach((item: HTMLElement) => {
             item.style.gridColumn = '1 / -1';
           });
+
+      if (infiniteLoader) {
+        infiniteLoader.style.gridColumn = '1 / -1';
+      }
     } else {
       parentComponent.style.removeProperty('display');
       parentComponent.style.removeProperty('grid-gap');
@@ -112,6 +118,10 @@ class DisplayHandler extends Component<DisplayHandlerProps, State> {
           .forEach((item: HTMLElement) => {
             item.style.removeProperty('grid-column');
           });
+
+      if (infiniteLoader) {
+        infiniteLoader.style.removeProperty('grid-column');
+      }
     }
   }
 
@@ -125,11 +135,13 @@ class DisplayHandler extends Component<DisplayHandlerProps, State> {
 
       parentComponent.style.display = 'block';
       [].forEach.call(parentComponent.children, (item: HTMLElement) => {
-        item.style.display = 'block';
-        const nextEl = item.nextElementSibling;
+        if (!item.classList.contains('__infinite-loader')) {
+          item.style.display = 'block';
+          const nextEl = item.nextElementSibling;
 
-        if (!showGroupSeparatorAtTheBottom || !nextEl || !nextEl.classList.contains('___list-separator')) {
-          item.style.margin = `0 0 ${rowGap}`;
+          if (!showGroupSeparatorAtTheBottom || !nextEl || !nextEl.classList.contains('___list-separator')) {
+            item.style.margin = `0 0 ${rowGap}`;
+          }
         }
       });
     } else {

--- a/src/subComponents/InfiniteLoader.tsx
+++ b/src/subComponents/InfiniteLoader.tsx
@@ -1,0 +1,176 @@
+import React, {Component, createRef, CSSProperties} from 'react';
+import {isFunction} from '../utils/isType';
+import DefaultLoadIndicator from './DefaultLoadIndicator';
+import {bool, element, func, node, oneOf, oneOfType} from 'prop-types';
+
+export interface InfiniteLoaderInterface {
+  loadingIndicator: () => JSX.Element | JSX.Element | null;
+  loadingIndicatorPosition: string;
+  hasMore: boolean;
+  loadMore: () => void;
+}
+
+interface State {
+  scrollingContainer: HTMLElement | null;
+  loadIndicatorContainer: HTMLDivElement | null;
+  loading: boolean;
+}
+
+class InfiniteLoader extends Component<InfiniteLoaderInterface, State> {
+  static propTypes = {
+    hasMore: bool.isRequired,
+    loadMore: func.isRequired,
+    loadingIndicator: oneOfType([func, node, element]),
+    loadingIndicatorPosition: oneOf(['left', 'center', 'right', '']),
+  };
+
+  static defaultProps = {
+    loadingIndicatorPosition: 'left'
+  };
+
+  state: State = {
+    loadIndicatorContainer: null,
+    loading: false,
+    scrollingContainer: null
+  };
+
+  loaderContainerRef = createRef<HTMLDivElement>();
+
+  // track the last scroll position so when new dom elements are inserted to avoid scroll jump
+  lastScrollTop = 0;
+
+  // a loading flag which is faster to check and update than "loading" state
+  waitingForUpdate = false;
+
+  mounted = true;
+
+  // keep track of the dom items in the list
+  currentItemsCount = 0;
+
+  componentDidMount(): void {
+    this.mounted = true;
+    const {current: loadIndicatorContainer}: any = this.loaderContainerRef;
+
+    if (loadIndicatorContainer) {
+      this.setState({
+        loadIndicatorContainer,
+        scrollingContainer: loadIndicatorContainer.parentNode,
+      }, () => {
+        this.currentItemsCount = this.getScrollingContainerChildrenCount();
+        this.setupScrollingContainerEventsListener();
+      });
+    } else {
+      console.warn('FlatList: it was not possible to get container\'s ref. ' +
+          'Infinite scrolling pagination will not be possible');
+    }
+  }
+
+  componentDidUpdate() {
+    // reset scroll position to where last was
+    if (this.state.scrollingContainer) {
+      this.state.scrollingContainer.scrollTop = this.lastScrollTop;
+    }
+
+    this.checkIfListChanged();
+  }
+
+  componentWillUnmount(): void {
+    this.setupScrollingContainerEventsListener(true);
+    this.mounted = false;
+  }
+
+  // update the loading flags and items count whether "hasMore" is false or list changed
+  checkIfListChanged() {
+    const currentItemsCount = this.getScrollingContainerChildrenCount();
+
+    if (this.currentItemsCount !== currentItemsCount || !this.props.hasMore) {
+      this.currentItemsCount = currentItemsCount;
+      this.waitingForUpdate = false;
+      if (this.state.loading) {
+        this.setState({loading: false});
+      }
+    }
+
+    this.checkIfLoadingIsNeeded();
+  }
+
+  getScrollingContainerChildrenCount = () => {
+    const {scrollingContainer} = this.state;
+
+    if (scrollingContainer) {
+      return Math.max(0, scrollingContainer.children.length);
+    }
+
+    return 0;
+  }
+
+  setupScrollingContainerEventsListener = (removeEvent = false) => {
+    const {scrollingContainer} = this.state;
+
+    if (scrollingContainer) {
+      ['scroll', 'mousewheel', 'touchmove'].forEach((event: string) => {
+        if (removeEvent) {
+          scrollingContainer.removeEventListener(event, this.checkIfLoadingIsNeeded, true);
+        } else {
+          scrollingContainer.addEventListener(event, this.checkIfLoadingIsNeeded, true);
+        }
+      });
+    }
+  }
+
+  // show or hide loading indicators based on scroll position
+  // calls the "loadMore" function when is needed
+  checkIfLoadingIsNeeded = () => {
+    if (!this.mounted) {
+        return;
+    }
+
+    const {scrollingContainer, loadIndicatorContainer} = this.state;
+    if (scrollingContainer && loadIndicatorContainer) {
+      const {scrollTop, offsetTop, clientHeight} = scrollingContainer;
+      this.lastScrollTop = scrollTop;
+
+      if (!this.props.hasMore || this.waitingForUpdate) {
+        return;
+      }
+
+      const loaderPosition = (loadIndicatorContainer.offsetTop - scrollTop);
+      const startingPoint = offsetTop + clientHeight;
+
+      if (loaderPosition <= startingPoint) {
+        this.waitingForUpdate = true;
+        if (!this.state.loading) {
+          this.setState({loading: true}, this.props.loadMore);
+        }
+      }
+    }
+  }
+
+  render() {
+    const {loading} = this.state;
+    const {hasMore, loadingIndicator, loadingIndicatorPosition} = this.props;
+
+    // do not remove the element from the dom so the ref is not broken but set it invisible enough
+    const styles: CSSProperties = {
+      display: 'flex',
+      height: hasMore ? 'auto' : 0,
+      justifyContent: loadingIndicatorPosition === 'center' ? loadingIndicatorPosition :
+          loadingIndicatorPosition === 'right' ? 'flex-end' : 'flex-start',
+      padding: hasMore ? '5px 0' : 0,
+      visibility: (loading && hasMore) ? 'visible' : 'hidden',
+    };
+
+    return (
+      <div ref={this.loaderContainerRef} className='__infinite-loader' style={styles}>
+        {
+          hasMore &&
+          (loadingIndicator ?
+              (isFunction(loadingIndicator) ? loadingIndicator() : loadingIndicator) :
+              DefaultLoadIndicator)
+        }
+      </div>
+    );
+  }
+}
+
+export default InfiniteLoader;


### PR DESCRIPTION
this
-- introduces pagination feature through a simple(MVP) infinite loader to flatlist using props `hasMoreItems`, `loadMoreItems`, `paginationLoadingIndicator` and `paginationLoadingIndicatorPosition`.
-- fixes weird props being added to html tag